### PR TITLE
Make labkey.init extendable

### DIFF
--- a/images/labkey/rstudio-base/Rprofile.site
+++ b/images/labkey/rstudio-base/Rprofile.site
@@ -22,7 +22,7 @@ labkey.init <- function(apiKey="")
   if (hasViewer && !is.null(baseUrl))
     rstudioapi::viewer(paste(baseUrl,"rstudio-viewer.view",sep='/'));
     
-  if (exists("labkey.extend")) labkey.extend()
+  if (exists("labkey.init.extend")) labkey.init.extend()
 }
 
 .First <- function()

--- a/images/labkey/rstudio-base/Rprofile.site
+++ b/images/labkey/rstudio-base/Rprofile.site
@@ -21,6 +21,8 @@ labkey.init <- function(apiKey="")
     baseUrl <- labkey.properties$url$base;
   if (hasViewer && !is.null(baseUrl))
     rstudioapi::viewer(paste(baseUrl,"rstudio-viewer.view",sep='/'));
+    
+  if (exists("labkey.extend")) labkey.extend()
 }
 
 .First <- function()


### PR DESCRIPTION
Instead of copying and pasting the changes from this file to Rprofile.site in my own extended docker image (https://github.com/RGLab/LabKeyModules/blob/master/Scripts/Rprofile.site), I can now append a function called `labkey.extend` to the end of `Rprofile.site`, so we can extend `labkey.init` and/or overwrite some of the variables or settings already done in `labkey.init`.

My `Rprofile.site` will look like this:
```R
labkey.extend <- function() {
  if (hasViewer && !is.null(baseUrl))
    rstudioapi::viewer(paste(baseUrl,"rstudio-viewer.html",sep='/'));

  hasPreview <- FALSE
  try (hasPreview <- rstudioapi::hasFun("previewRd"))
  if (hasPreview) try(rstudioapi::previewRd("/ImmuneSpace-RStudio.Rd"), silent = TRUE)
}
```