### PR TITLE
Item 8859: RStudio Pro (1.4.1106-5) integration issue

### DIFF
--- a/images/labkey/rstudio-base/Dockerfile
+++ b/images/labkey/rstudio-base/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=3.6.3
+ARG VERSION=4.0.5
 FROM rocker/rstudio:${VERSION}
 
 RUN apt-get update && \

--- a/images/labkey/rstudio-base/cleanupSessionFiles.sh
+++ b/images/labkey/rstudio-base/cleanupSessionFiles.sh
@@ -16,8 +16,8 @@ MOUNT=$1
 # limitations under the License.
 #
 
-pushd "$MOUNT"/.rstudio || exit 1
+pushd "$MOUNT" || exit 1
 
-find . -name session-persistent-state -type f -exec  sed -i 's/abend="1"/abend="0"/' {} +
+find .rstudio -name session-persistent-state -type f -exec  sed -i 's/abend="1"/abend="0"/' {} +
 
 popd || exit 1

--- a/images/labkey/rstudio-base/cleanupSessionFiles.sh
+++ b/images/labkey/rstudio-base/cleanupSessionFiles.sh
@@ -18,6 +18,6 @@ MOUNT=$1
 
 pushd "$MOUNT" || exit 1
 
-find .rstudio -name session-persistent-state -type f -exec  sed -i 's/abend="1"/abend="0"/' {} +
+find . -name session-persistent-state -type f -exec  sed -i 's/abend="1"/abend="0"/' {} +
 
 popd || exit 1

--- a/images/labkey/rstudio-singleuser/Dockerfile
+++ b/images/labkey/rstudio-singleuser/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=3.6.3
+ARG VERSION=4.0.5
 FROM rocker/rstudio:${VERSION}
 
 COPY rstudio-singleuser /

--- a/images/labkey/rstudio/Dockerfile
+++ b/images/labkey/rstudio/Dockerfile
@@ -1,4 +1,5 @@
-FROM labkey/rstudio-base
+ARG VERSION=latest
+FROM labkey/rstudio-base:${VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends  \

--- a/images/labkey/rstudio/make
+++ b/images/labkey/rstudio/make
@@ -2,7 +2,7 @@
 
 echo requires docker 17.05.0 or greater
 
-export VERSION=${1-3.6.3}
+export VERSION=${1-4.0.5}
 shift
 
 echo build VERSION=${VERSION}


### PR DESCRIPTION
#### Rationale
Update to use a latest rstudio image version (with R version 4.0.5)

#### Related Pull Requests
* https://github.com/LabKey/rstudio/pull/86

#### Changes
* update version param to 4.0.5
* bring back image version tag to allow building multiple rstudio images
* fix linux LF
