### PR TITLE
Fix docker rstudio image

### DIFF
--- a/images/labkey/rsandbox-ver/Dockerfile
+++ b/images/labkey/rsandbox-ver/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/r-ver:${VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apt-utils && \
-    apt-get install -y --no-install-recommends dos2unix nano procps libxml2-dev xvfb sudo && \
+    apt-get install -y --no-install-recommends dos2unix nano procps libxml2-dev xvfb zlib1g-dev sudo && \
     apt-get install -y --no-install-recommends  \
 	    curl libcurl4-openssl-dev \
         libgd-dev libcairo2 libcairo2-dev libxt-dev pandoc \

--- a/images/labkey/rstudio-base/Dockerfile
+++ b/images/labkey/rstudio-base/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/rstudio:${VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apt-utils && \
-    apt-get install -y --no-install-recommends dos2unix nano procps libxml2-dev xvfb && \
+    apt-get install -y --no-install-recommends dos2unix nano procps libxml2-dev xvfb zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Rationale
httpuv package installation now requires zlib. This PR adds a step to install zlib dev tool prior to installing R packages.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* install zlib1g-dev
