### PR TITLE
Bump R version to 4.5.1

### DIFF
--- a/images/labkey/rsandbox-ver/Dockerfile
+++ b/images/labkey/rsandbox-ver/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=3.6.3
+ARG VERSION=4.5.1
 FROM rocker/r-ver:${VERSION}
 
 RUN apt-get update && \

--- a/images/labkey/rsandbox/Dockerfile
+++ b/images/labkey/rsandbox/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=3.6.3
+ARG VERSION=4.5.1
 FROM rocker/r-ver:${VERSION}
 
 RUN apt-get update && \
@@ -30,7 +30,7 @@ RUN useradd docker || true \
 
 COPY install.R /
 RUN dos2unix install.R && \
-    R --no-site-file -f install.R &&  \
+    R -f install.R &&  \
     chmod -R 755 /usr/local/lib/R/site-library
 
 CMD ["su", "docker", "-c", "/bin/bash"]

--- a/images/labkey/rsandbox/README.md
+++ b/images/labkey/rsandbox/README.md
@@ -1,13 +1,13 @@
 labkey/rsandbox:latest
 ======
 
-Dockerfile for building Dockerized LabKey R image using with the latest R release version. 
+Dockerfile for building a Dockerized LabKey R image.
 
-Run `./make` to generate R image `labkey/rsandbox:latest`. 
+Run `./make` to generate R image `labkey/rsandbox:latest`.
 
-Note that actual R version might differ based on latest R version at the time the image is built. 
+The R version is pinned by `ARG VERSION` in the Dockerfile. Override it per-build with `./make --build-arg VERSION=<version>`, but note that tags older than R 4.0 are based on EOL Debian releases whose apt mirrors no longer resolve.
 
-To tag the image with the actual R version at the time of build, change `latest` in `make` file to the latest R version, for example: `3.5.1`.
+To tag the image with the R version instead of `latest`, change `latest` in the `make` file, for example: `4.5.1`.
 
 For more information, see:
 

--- a/images/labkey/rsandbox/install.R
+++ b/images/labkey/rsandbox/install.R
@@ -14,9 +14,7 @@
 #  limitations under the License.
 ##
 
-repos.options <- getOption("repos")
-repos.options["CRAN"] <- 'https://cran.rstudio.com/'
-options(repos = repos.options)
+# Repos come from the base image's Rprofile.site: a pinned P3M snapshot that serves binaries.
 
 if (!require("pacman")) install.packages("pacman")
 


### PR DESCRIPTION
#### Rationale
Previous pinned R version for this image (3.6.3) is past EOL. Bumping to a later version for the R sandbox image only.